### PR TITLE
Feature/core reset overlay settings

### DIFF
--- a/frontend/ipc/SettingsEvents.js
+++ b/frontend/ipc/SettingsEvents.js
@@ -1,0 +1,10 @@
+const { ipcMain } = require('electron');
+const { resetSettings } = require('../utils/overlay_settings');
+
+function registerSettingsEvents() {
+  ipcMain.on('reset-overlay-settings', () => {
+    resetSettings();
+  });
+}
+
+module.exports = registerSettingsEvents;

--- a/frontend/ipc/SettingsEvents.js
+++ b/frontend/ipc/SettingsEvents.js
@@ -1,16 +1,20 @@
 const { ipcMain } = require('electron');
 const { resetSettings } = require('../utils/overlay_settings');
 const { overlays } = require('../windows/overlayWindow');
+const { clearZoomCache } = require('../utils/overlay_zoom');
 
 function registerSettingsEvents() {
   ipcMain.on('reset-overlay-settings', () => {
-    // close all overlays
+    // Сlose all overlays
     for (const overlay of Object.values(overlays)) {
         if (!overlay.isDestroyed()) overlay.destroy();
     }
 
     // delete settings file
     resetSettings();
+    
+    // Clear zoom cache
+    clearZoomCache();
   });
 }
 

--- a/frontend/ipc/SettingsEvents.js
+++ b/frontend/ipc/SettingsEvents.js
@@ -1,8 +1,15 @@
 const { ipcMain } = require('electron');
 const { resetSettings } = require('../utils/overlay_settings');
+const { overlays } = require('../windows/overlayWindow');
 
 function registerSettingsEvents() {
   ipcMain.on('reset-overlay-settings', () => {
+    // close all overlays
+    for (const overlay of Object.values(overlays)) {
+        if (!overlay.isDestroyed()) overlay.destroy();
+    }
+
+    // delete settings file
     resetSettings();
   });
 }

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -3,6 +3,7 @@ const { app } = require('electron');
 const { createMainWindow } = require('./windows/mainWindow');
 const registerRadarEvents = require('./ipc/RadarEvents');
 const registerLeaderboardEvents = require('./ipc/LeaderboardEvents');
+const registerSettingsEvents = require('./ipc/SettingsEvents');
 const { startBackend, stopBackend } = require('./utils/backendManager');
 
 let mainWindow = null;
@@ -20,6 +21,7 @@ async function createWindow() {
 
   registerRadarEvents();
   registerLeaderboardEvents();
+  registerSettingsEvents();
 
   mainWindow.on('closed', () => {
     mainWindow = null;

--- a/frontend/preload.js
+++ b/frontend/preload.js
@@ -20,5 +20,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setCardBgOpacity: (overlayName, value) =>
       ipcRenderer.send('set-card-bg-opacity', { overlayName, value }),
   getCardBgOpacity: (overlayName) =>
-      ipcRenderer.invoke('get-card-bg-opacity', overlayName)
+      ipcRenderer.invoke('get-card-bg-opacity', overlayName),
+
+  // Reset overlay settings
+  resetOverlaySettings: () =>
+    ipcRenderer.send('reset-overlay-settings')
 });

--- a/frontend/static/css/main.css
+++ b/frontend/static/css/main.css
@@ -72,6 +72,12 @@ body.no-scroll {
   gap: var(--spacing-lg);
 }
 
+.menu-grid > a:last-child .menu-card {
+  height: 120px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 .menu-card {
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-primary);
@@ -228,27 +234,6 @@ body.no-scroll {
   text-align: center;
 }
 
-.overlay-button {
-  width: 100%;
-  padding: var(--spacing-sm) var(--spacing-lg);
-  border-radius: var(--border-radius-md);
-  border: none;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--transition);
-  width: 300px;
-}
-
-.overlay-button.active-btn {
-  background-color: var(--accent);
-  color: var(--bg-primary);
-}
-
-.overlay-button.active-btn:hover {
-  background-color: #e5e5e5;
-}
-
 /* Changelog View */
 .changelog-list {
   display: flex;
@@ -299,41 +284,29 @@ body.no-scroll {
   font-weight: 300;
 }
 
-.toggle {
-  width: 48px;
-  height: 24px;
-  background-color: var(--border-hover);
-  border-radius: var(--border-radius-lg);
-  position: relative;
+/* Buttons */
+.button {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--border-radius-md);
+  border: none;
+  font-size: 0.875rem;
+  font-weight: 500;
   cursor: pointer;
-  transition: background-color var(--transition);
+  transition: all var(--transition);
+  width: 300px;
 }
 
-.toggle.active {
+.button.primary-btn {
   background-color: var(--accent);
+  color: var(--bg-primary);
 }
 
-.toggle-knob {
-  width: 20px;
-  height: 20px;
-  background-color: var(--bg-primary);
-  border-radius: 50%;
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  transition: left var(--transition);
+.button.primary-btn:hover {
+  background-color: #e5e5e5;
 }
 
-.toggle.active .toggle-knob {
-  left: 26px;
-}
-
-.menu-grid > a:last-child .menu-card {
-  height: 120px;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
+/* Detail View */
 .overlays-layout {
   display: grid;
   grid-template-columns: 220px 1fr;

--- a/frontend/templates/pages/card_detail/base_detail.html
+++ b/frontend/templates/pages/card_detail/base_detail.html
@@ -6,7 +6,7 @@
 
 <div>
   <div class="text-column">
-    <button id="OpenBtn" class="overlay-button active-btn">Open</button>
+    <button id="OpenBtn" class="button primary-btn">Open</button>
   </div>
   <div>
     <img

--- a/frontend/templates/pages/settings.html
+++ b/frontend/templates/pages/settings.html
@@ -18,10 +18,21 @@
 
 <div class="settings-list">
   <div class="setting-item">
-    <span class="setting-name">there's nothing here yet</span>
-    <div class="toggle">
-      <div class="toggle-knob"></div>
-    </div>
+    <span class="setting-name">Reset overlays settings</span>
+    <button id="reset-overlay-settings" class="overlay-button active-btn">Reset</button>
 </div>
 
+<script>
+  document
+    .getElementById('reset-overlay-settings')
+    .addEventListener('click', () => {
+      if (!confirm('Reset all overlay settings?')) {
+        return;
+      }
+
+      window.electronAPI.resetOverlaySettings();
+
+      alert('Overlay settings have been reset');
+    });
+</script>
 {% endblock %}

--- a/frontend/templates/pages/settings.html
+++ b/frontend/templates/pages/settings.html
@@ -19,7 +19,7 @@
 <div class="settings-list">
   <div class="setting-item">
     <span class="setting-name">Reset overlays settings</span>
-    <button id="reset-overlay-settings" class="overlay-button active-btn">Reset</button>
+    <button id="reset-overlay-settings" class="button primary-btn" style="width: auto;">Reset</button>
 </div>
 
 <script>

--- a/frontend/utils/overlay_settings.js
+++ b/frontend/utils/overlay_settings.js
@@ -27,4 +27,14 @@ function saveSettings(settings) {
   }
 }
 
-module.exports = { loadSettings, saveSettings };
+function resetSettings() {
+  try {
+    if (fs.existsSync(SETTINGS_PATH)) {
+      fs.unlinkSync(SETTINGS_PATH);
+    }
+  } catch (err) {
+    console.error('[settings] Failed to reset settings:', err);
+  }
+}
+
+module.exports = { loadSettings, saveSettings, resetSettings };


### PR DESCRIPTION
### Key features:
- https://github.com/onesch/redwave-overlays/issues/11#event-21671161841
1. Added the ability to reset overlay settings.
2. Preserve zoom in memory to prevent reset on opacity change.

<img width="534" height="221" alt="image" src="https://github.com/user-attachments/assets/c71d9f96-3226-4619-960a-bfcc3d147af3" />
