### PR TITLE
Feature/core overlay-auto-start-mode

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,29 +1,51 @@
 const { app } = require('electron');
 
 const { createMainWindow } = require('./windows/mainWindow');
+const { createOverlay } = require('./windows/overlayWindow');
+const { loadSettings } = require('./utils/overlay_settings');
+const overlaysConfig = require('./windows/overlays_config');
+const { startBackend, stopBackend } = require('./utils/backendManager');
+
 const registerRadarEvents = require('./ipc/RadarEvents');
 const registerLeaderboardEvents = require('./ipc/LeaderboardEvents');
 const registerTrackMapEvents = require('./ipc/TrackMapEvents');
 const registerSettingsEvents = require('./ipc/SettingsEvents');
-const { startBackend, stopBackend } = require('./utils/backendManager');
 
 let mainWindow = null;
 
+// Launches overlays that have AutoStart enabled.
+function autoStartOverlays() {
+  const settings = loadSettings();
+
+  for (const overlayName of Object.keys(overlaysConfig)) {
+    // Default to 'off' if setting is missing
+    const autoStart = settings[overlayName]?.AutoStart ?? 'off';
+    if (autoStart === 'on') {
+      createOverlay(overlayName);
+    }
+  }
+}
 
 async function createWindow() {
+  // Prevent multiple main windows
   if (mainWindow) {
     mainWindow.focus();
     return;
   }
 
+  // Wait for FastAPI backend to be ready
   await startBackend();
 
   mainWindow = createMainWindow();
 
+  // Register IPC event handlers for each overlay
   registerRadarEvents();
   registerLeaderboardEvents();
   registerSettingsEvents();
   registerTrackMapEvents();
+
+  // Open overlays marked as auto-start in settings
+  autoStartOverlays();
 
   mainWindow.on('closed', () => {
     mainWindow = null;

--- a/frontend/preload.js
+++ b/frontend/preload.js
@@ -42,6 +42,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onDisplayModeUpdate: (callback) =>
     ipcRenderer.on('update-display-mode', (_, value) => callback(value)),
 
+  // Auto-Start mode
+  setAutoStartMode: (overlayName, value) =>
+    ipcRenderer.send('set-auto-start-mode', { overlayName, value }),
+  getAutoStartMode: (overlayName) =>
+    ipcRenderer.invoke('get-auto-start-mode', overlayName),
+  onAutoStartModeUpdate: (callback) =>
+    ipcRenderer.on('update-auto-start-mode', (_, value) => callback(value)),
+
   // Reset overlay settings
   resetOverlaySettings: () =>
     ipcRenderer.send('reset-overlay-settings')

--- a/frontend/static/js/base_detail.js
+++ b/frontend/static/js/base_detail.js
@@ -19,10 +19,16 @@ class OverlayBase {
             garage:   document.getElementById('DisplayGarageBtn'),
         };
 
+        this.autoStartButtons = {
+            on:  document.getElementById('AutoStartOnBtn'),
+            off: document.getElementById('AutoStartOffBtn'),
+        };
+
         this.setupEventListeners();
         this.loadZoomSettings();
         this.loadOpacitySettings();
         this.loadDisplayMode();
+        this.loadAutoStartMode();
     }
 
     setupEventListeners() {
@@ -34,6 +40,9 @@ class OverlayBase {
         }
         Object.entries(this.displayButtons).forEach(([mode, btn]) => {
             if (btn) btn.addEventListener('click', () => this.handleDisplayModeChange(mode));
+        });
+        Object.entries(this.autoStartButtons).forEach(([value, btn]) => {
+            if (btn) btn.addEventListener('click', () => this.handleAutoStartModeChange(value));
         });
     }
 
@@ -85,6 +94,22 @@ class OverlayBase {
     applyDisplayMode(mode) {
         Object.entries(this.displayButtons).forEach(([key, btn]) => {
             if (btn) btn.classList.toggle('active', key === mode);
+        });
+    }
+
+    async loadAutoStartMode() {
+        const mode = await window.electronAPI.getAutoStartMode?.(this.overlayName);
+        this.applyAutoStartMode(mode ?? 'off');
+    }
+
+    handleAutoStartModeChange(value) {
+        window.electronAPI.setAutoStartMode?.(this.overlayName, value);
+        this.applyAutoStartMode(value);
+    }
+
+    applyAutoStartMode(value) {
+        Object.entries(this.autoStartButtons).forEach(([key, btn]) => {
+            if (btn) btn.classList.toggle('active', key === value);
         });
     }
 }

--- a/frontend/templates/pages/card_detail/base_detail.html
+++ b/frontend/templates/pages/card_detail/base_detail.html
@@ -53,6 +53,14 @@
   </div>
 </div>
 
+<div class="setting-container">
+  <div class="setting-label">Auto-Start:</div>
+  <div class="setting-value button-section">
+    <button id="AutoStartOnBtn">On</button>
+    <button id="AutoStartOffBtn" class="active">Off</button>
+  </div>
+</div>
+
 {% block additional_settings %}{% endblock %}
 
 <script src="{{ url_for('static', path='/js/base_detail.js') }}"></script>

--- a/frontend/utils/overlay_auto_start_mode.js
+++ b/frontend/utils/overlay_auto_start_mode.js
@@ -1,0 +1,28 @@
+const { ipcMain } = require('electron');
+const { loadSettings, saveSettings } = require('./overlay_settings');
+
+
+function registerOverlayAutoStartModeHandlers(overlays) {
+  ipcMain.handle('get-auto-start-mode', (e, overlayName) => {
+    const settings = loadSettings();
+    const value = settings[overlayName]?.AutoStart ?? 'off';
+    return value;
+  });
+
+  ipcMain.on('set-auto-start-mode', (e, { overlayName, value }) => {
+
+    const settings = loadSettings();
+    settings[overlayName] ||= {};
+    settings[overlayName].AutoStart = value;
+    saveSettings(settings);
+
+    const overlay = overlays[overlayName];
+    if (!overlay || overlay.isDestroyed()) {
+      return;
+    }
+
+    overlay.webContents.send('update-auto-start-mode', value);
+  });
+}
+
+module.exports = { registerOverlayAutoStartModeHandlers };

--- a/frontend/windows/overlayWindow.js
+++ b/frontend/windows/overlayWindow.js
@@ -7,6 +7,7 @@ const { applySavedPosition, registerPositionHandlers, watchOverlayPosition } = r
 const { registerOverlayOpacityHandlers } = require('../utils/overlay_card_opacity');
 const { registerOverlayTrackTypeHandlers } = require('../utils/overlay_track_type');
 const { registerOverlayDisplayModeHandlers } = require('../utils/overlay_display_mode');
+const { registerOverlayAutoStartModeHandlers } = require('../utils/overlay_auto_start_mode');
 
 const overlays = {};
 let overlayCount = 0;
@@ -17,6 +18,7 @@ registerPositionHandlers(overlays);
 registerOverlayOpacityHandlers(overlays);
 registerOverlayTrackTypeHandlers(overlays);
 registerOverlayDisplayModeHandlers(overlays);
+registerOverlayAutoStartModeHandlers(overlays);
 
 function createOverlay(route, options = {}) {
   if (overlays[route] && !overlays[route].isDestroyed()) {
@@ -58,7 +60,7 @@ function createOverlay(route, options = {}) {
   applySavedZoom(overlay, route);
   applySavedPosition(overlay, route);
   watchOverlayPosition(overlay, route);
-  // opacity is handled separately by overlay_card_opacity module
+  // opacity, track-type, display-mode, auto-start-mode is handled by a separate module
 
   overlay.on('closed', () => {
     delete overlays[route];


### PR DESCRIPTION
### Key features:

- Chore:

1. introduced the ability to select a auto-start mode for the overlay window. https://github.com/onesch/redwave-overlays/issues/11

- Image:
<img width="234" height="35" alt="image" src="https://github.com/user-attachments/assets/0df3ee11-6624-4e9f-be65-7923cb46d100" />

