### PR TITLE
fix(track-map): override inline fill on SVG path elements to prevent solid shape rendering

### DIFF
--- a/frontend/templates/overlays/track_map.html
+++ b/frontend/templates/overlays/track_map.html
@@ -92,9 +92,13 @@ class TrackMapUpdater extends BaseUpdater {
 
             const outer = el.cloneNode(true);
             outer.setAttribute('class', 'track outer');
+            outer.style.fill = 'none';
+            outer.style.stroke = '';
 
             const surface = el.cloneNode(true);
             surface.setAttribute('class', 'track surface');
+            surface.style.fill = 'none';
+            surface.style.stroke = '';
 
             group.appendChild(outer);
             group.appendChild(surface);


### PR DESCRIPTION
Inline `style="fill: #fff"` on some track SVG paths (e.g. Sonoma) 
overrode CSS class rules. Now explicitly set `style.fill = 'none'` 
on cloned elements so the track renders as a stroked line.