### PR TITLE
Feature/radar visibility mode

### DIFF
--- a/backend/services/radar/constants.py
+++ b/backend/services/radar/constants.py
@@ -1,6 +1,6 @@
 RED_M = 4.5
 YEL_M = 6.5
-MAX_SHOW_DIST = 15.0
+MAX_SHOW_DIST = 15.0  # Max distance to show on radar, in meters, reused in RadarUpdater this.MAX_SHOW_DIST.
 SIDE_WINDOW_M = 8.0
 
 CLR_OFF = 0

--- a/frontend/preload.js
+++ b/frontend/preload.js
@@ -56,6 +56,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onOverlayMovementStateUpdate: (callback) =>
     ipcRenderer.on('overlay-movement-state-updated', (_, value) => callback(value)),
 
+  // Radar visibility mode
+  setRadarVisibility: (overlayName, value) =>
+    ipcRenderer.send('set-radar-visibility', { overlayName, value }),
+  getRadarVisibility: (overlayName) =>
+    ipcRenderer.invoke('get-radar-visibility', overlayName),
+  onRadarVisibilityUpdate: (callback) =>
+    ipcRenderer.on('update-radar-visibility', (_, value) => callback(value)),
+
   // Reset overlay settings
   resetOverlaySettings: () =>
     ipcRenderer.send('reset-overlay-settings'),

--- a/frontend/static/css/main.css
+++ b/frontend/static/css/main.css
@@ -446,6 +446,7 @@ body.no-scroll {
 .tooltip:hover::before {
   opacity: 1;
   transition-delay: 0.8s;
+  text-transform: lowercase;
 }
 
 /* TOP */

--- a/frontend/static/css/main.css
+++ b/frontend/static/css/main.css
@@ -440,13 +440,13 @@ body.no-scroll {
     opacity 0.2s ease,
     transform 0.2s ease;
   transition-delay: 0s;
+  text-transform: lowercase;
 }
 
 /* Show */
 .tooltip:hover::before {
   opacity: 1;
   transition-delay: 0.8s;
-  text-transform: lowercase;
 }
 
 /* TOP */

--- a/frontend/static/css/overlays/radar.css
+++ b/frontend/static/css/overlays/radar.css
@@ -5,6 +5,9 @@
   aspect-ratio: 1 / 1;
   border-radius: 50%;
   overflow: hidden;
+
+  opacity: 1;
+  transition: opacity 0.5s ease;
 }
 
 .my-car {

--- a/frontend/templates/overlays/radar.html
+++ b/frontend/templates/overlays/radar.html
@@ -38,11 +38,8 @@ class RadarUpdater extends BaseUpdater {
     async init() {
         await super.init();
 
-        // Fetch the saved visibility mode
-        const savedMode =
-        await window.electronAPI.getRadarVisibility?.('radar');
-
-        this.radarMode = savedMode ?? 'dim';
+        // Get saved radar visibility mode
+        this.radarMode = await window.electronAPI.getRadarVisibility?.('radar');
 
         // Listen for updates to the radar visibility mode
         window.electronAPI.onRadarVisibilityUpdate?.((mode) => {

--- a/frontend/templates/overlays/radar.html
+++ b/frontend/templates/overlays/radar.html
@@ -32,8 +32,23 @@ class RadarUpdater extends BaseUpdater {
         this.MAX_DIST = 15.0;
         this.RADAR_H = 260;
         this.CENTER_Y = this.RADAR_H / 2;
+        this.MAX_SHOW_DIST = 15.0;
     }
 
+    async init() {
+        await super.init();
+
+        // Fetch the saved visibility mode
+        const savedMode =
+        await window.electronAPI.getRadarVisibility?.('radar');
+
+        this.radarMode = savedMode ?? 'dim';
+
+        // Listen for updates to the radar visibility mode
+        window.electronAPI.onRadarVisibilityUpdate?.((mode) => {
+            this.radarMode = mode;
+        });
+    }
     async renderOverlay(data) {
         this.renderRadar(data);
     }
@@ -78,6 +93,56 @@ class RadarUpdater extends BaseUpdater {
 
         this.setSide(document.getElementById("side-left"), data.left);
         this.setSide(document.getElementById("side-right"), data.right);
+
+        this.updateRadarVisibility(data);
+    }
+
+    // Update radar visibility based on the current mode and distances
+    updateRadarVisibility(data) {
+        const el = document.querySelector(".radar-container");
+
+        const mode = this.radarMode;
+
+        const distances = [];
+        if (data.ahead_m != null) distances.push(data.ahead_m);
+        if (data.behind_m != null) distances.push(data.behind_m);
+
+        const nearest = distances.length ? Math.min(...distances) : null;
+
+        // Always show if any cars are nearby
+        if (data.left || data.right) {
+            el.style.display = 'block';
+            el.style.opacity = 1;
+            return;
+        }
+
+        // Always show overlay
+        if (mode === 'show') {
+            el.style.display = 'block';
+            el.style.opacity = 1;
+            return;
+        }
+
+        // Hide if no cars nearby
+        if (mode === 'hide') {
+            if (nearest == null || nearest > this.MAX_SHOW_DIST) {
+                el.style.opacity = 0;
+                el.style.display = 'none';
+                return;
+            }
+            el.style.display = 'block';
+            el.style.opacity = 1;
+            return;
+        }
+
+        // Dim if no cars nearby
+        el.style.display = 'block';
+
+        if (nearest == null || nearest > this.MAX_SHOW_DIST) {
+            el.style.opacity = 0.35;
+        } else {
+            el.style.opacity = 1;
+        }
     }
 }
 

--- a/frontend/templates/pages/card_detail/radar.html
+++ b/frontend/templates/pages/card_detail/radar.html
@@ -3,17 +3,54 @@
 {% block title %}Overlays - {{ card_data.title }}{% endblock %}
 
 {% block additional_settings %}
+<div class="setting-container">
+  <div class="setting-label">Visibility:</div>
+  <div class="setting-value button-section">
+    <button id="dimBtn" class="active">dim</button>
+    <button id="showBtn">show</button>
+    <button id="hideBtn">hide</button>
+  </div>
+</div>
 {% endblock %}
 
 {% block overlay_scripts %}
 <script>
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     const overlayName = 'radar';
     const overlay = new OverlayBase(overlayName);
     
+    const showBtn = document.getElementById('showBtn');
+    const dimBtn = document.getElementById('dimBtn');
+    const hideBtn = document.getElementById('hideBtn');
+
     document.getElementById('OpenBtn').addEventListener('click', () => {
         window.electronAPI.openOverlay(overlayName);
     });
+
+    const saved = await window.electronAPI.getRadarVisibility(overlayName);
+    applyVisibility(saved || 'dim');
+
+    hideBtn.onclick = () => {
+        window.electronAPI.setRadarVisibility(overlayName, 'hide');
+        applyVisibility('hide');
+    };
+
+    dimBtn.onclick = () => {
+        window.electronAPI.setRadarVisibility(overlayName, 'dim');
+        applyVisibility('dim');
+    };
+
+    showBtn.onclick = () => {
+        window.electronAPI.setRadarVisibility(overlayName, 'show');
+        applyVisibility('show');
+    };
+
+    function applyVisibility(mode) {
+        hideBtn.classList.toggle('active', mode === 'hide');
+        dimBtn.classList.toggle('active', mode === 'dim');
+        showBtn.classList.toggle('active', mode === 'show');
+    }
+
 });
 </script>
 {% endblock %}

--- a/frontend/templates/pages/card_detail/radar.html
+++ b/frontend/templates/pages/card_detail/radar.html
@@ -5,11 +5,11 @@
 {% block additional_settings %}
 <div class="setting-container">
   <div class="setting-label">Visibility:</div>
-  <div class="setting-value button-section">
-    <button id="dimBtn" class="active">dim</button>
-    <button id="showBtn">show</button>
-    <button id="hideBtn">hide</button>
-  </div>
+    <div class="setting-value button-section">
+    <button id="dimBtn" class="active tooltip tooltip-top" data-tooltip="dim radar when no cars are nearby">dim</button>
+    <button id="showBtn" class="tooltip tooltip-top" data-tooltip="always show radar regardless of distance">show</button>
+    <button id="hideBtn" class="tooltip tooltip-top" data-tooltip="hide radar when no cars are nearby">hide</button>
+    </div>
 </div>
 {% endblock %}
 

--- a/frontend/templates/pages/card_detail/radar.html
+++ b/frontend/templates/pages/card_detail/radar.html
@@ -27,8 +27,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.electronAPI.openOverlay(overlayName);
     });
 
-    const saved = await window.electronAPI.getRadarVisibility(overlayName);
-    applyVisibility(saved || 'dim');
+    const savedVisibilityMode = await window.electronAPI.getRadarVisibility(overlayName);
+    applyVisibility(savedVisibilityMode);
 
     hideBtn.onclick = () => {
         window.electronAPI.setRadarVisibility(overlayName, 'hide');

--- a/frontend/templates/pages/card_detail/track_map.html
+++ b/frontend/templates/pages/card_detail/track_map.html
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     const savedTrackType = await window.electronAPI.getTrackType(overlayName);
-    applyTrackType(savedTrackType || 'linear');
+    applyTrackType(savedTrackType);
 
     linearBtn.addEventListener('click', () => {
         window.electronAPI.setTrackType(overlayName, 'linear');

--- a/frontend/utils/overlays/radar_visibility_mode.js
+++ b/frontend/utils/overlays/radar_visibility_mode.js
@@ -1,0 +1,33 @@
+const { registerOverlaySetting } = require('./base_handler');
+
+const currentRadarModes = {};
+
+function getRadarVisibility(overlayName, settings) {
+  if (overlayName !== 'radar') return undefined;
+
+  return (
+    currentRadarModes[overlayName] ??
+    settings[overlayName]?.RadarVisibility ??
+    'dim'
+  );
+}
+
+function registerOverlayRadarVisibilityHandlers(overlays) {
+  registerOverlaySetting({
+    overlays,
+    getChannel: 'get-radar-visibility',
+    setChannel: 'set-radar-visibility',
+    settingKey: 'RadarVisibility',
+    defaultValue: 'dim',
+    updateEvent: 'update-radar-visibility',
+
+    afterSet: ({ overlayName, value }) => {
+      currentRadarModes[overlayName] = value;
+    },
+  });
+}
+
+module.exports = {
+  registerOverlayRadarVisibilityHandlers,
+  getRadarVisibility,
+};

--- a/frontend/windows/overlayWindow.js
+++ b/frontend/windows/overlayWindow.js
@@ -10,6 +10,7 @@ const { registerOverlayTrackTypeHandlers } = require('../utils/overlays/track_ty
 const { registerOverlayDisplayModeHandlers } = require('../utils/overlays/display_mode');
 const { registerOverlayAutoStartModeHandlers } = require('../utils/overlays/auto_start_mode');
 const { registerOverlayMovementHandlers } = require('../utils/overlays/overlay_movement');
+const { registerOverlayRadarVisibilityHandlers } = require('../utils/overlays/radar_visibility_mode');
 
 const overlays = {};
 let overlayCount = 0;
@@ -22,6 +23,7 @@ registerOverlayTrackTypeHandlers(overlays);
 registerOverlayDisplayModeHandlers(overlays);
 registerOverlayAutoStartModeHandlers(overlays);
 registerOverlayMovementHandlers(overlays);
+registerOverlayRadarVisibilityHandlers(overlays);
 
 function createOverlay(route, options = {}) {
   if (overlays[route] && !overlays[route].isDestroyed()) {


### PR DESCRIPTION
### Key features:
- Overlay:
1. add radar visibility modes to dim or hide the overlay when no cars are nearby. https://github.com/onesch/redwave-overlays/issues/12

- UI/UX:
2. [add tooltips for visibility mode buttons](https://github.com/onesch/redwave-overlays/pull/39/commits/dcc2a5cd186ceb23249c24f5dabba86abd1bd66f) (dim / show / hide) for better usability.

- Fixes:
3. [removed redundant fallback values](https://github.com/onesch/redwave-overlays/pull/39/commits/8969ac3f6ce8622252daa6d4dd3083c011a2fcaa) in radar and track-map logic (single source of truth for state).

- Image:
<img width="482" height="224" alt="Screenshot 2026-06-22 162955" src="https://github.com/user-attachments/assets/350b3e65-cdf1-4a38-bad6-073a416197a2" />
