### PR TITLE
Feature/leaderboard irating calculation delta

### DIFF
--- a/backend/services/leaderboard/car_data_builder.py
+++ b/backend/services/leaderboard/car_data_builder.py
@@ -36,6 +36,7 @@ class CarDataBuilder(BaseCarBuilder):
 
         return {
             **base_car,
+            "driver_id": driver.get("UserID", idx),
             "pos": self._resolve_position(idx, ctx),
             "name": self._get_first_name(driver),
             "irating": driver.get("IRating"),
@@ -65,6 +66,49 @@ class CarDataBuilder(BaseCarBuilder):
     def _get_first_name(self, driver: dict) -> str:
         names = driver.get("UserName", "").strip().split()
         return names[0] if names else ""
+
+    def build_irating_results(
+        self,
+        ctx: LeaderboardContext,
+    ) -> list[dict[str, Any]]:
+        """
+        Build driver data required for iRating calculation.
+        """
+        drivers = []
+
+        for car_idx, driver in enumerate(ctx.drivers):
+            if self._is_pace_car(driver):
+                continue
+
+            irating = driver.get("IRating")
+
+            if not isinstance(irating, int):
+                continue
+
+            position = None
+
+            if car_idx < len(ctx.positions):
+                raw_position = ctx.positions[car_idx]
+
+                if isinstance(raw_position, int) and raw_position > 0:
+                    position = raw_position
+
+            drivers.append(
+                {
+                    "id": driver.get("UserID", car_idx),
+                    "irating": irating,
+                    "position": position,
+                    "started": position is not None,
+                }
+            )
+
+        return sorted(
+            drivers,
+            key=lambda d: (
+                d["position"] is None,
+                d["position"] or 9999,
+            ),
+        )
 
     def _format_lap_dist(self, idx: int, ctx: LeaderboardContext) -> float:
         dist: float = ctx.lap_dist_pct[idx]

--- a/backend/services/leaderboard/car_data_builder.py
+++ b/backend/services/leaderboard/car_data_builder.py
@@ -67,7 +67,7 @@ class CarDataBuilder(BaseCarBuilder):
         names = driver.get("UserName", "").strip().split()
         return names[0] if names else ""
 
-    def build_irating_results(
+    def get_irating_drivers(
         self,
         ctx: LeaderboardContext,
     ) -> list[dict[str, Any]]:
@@ -80,25 +80,20 @@ class CarDataBuilder(BaseCarBuilder):
             if self._is_pace_car(driver):
                 continue
 
-            irating = driver.get("IRating")
+            position = self._resolve_position(car_idx, ctx)
+            started = position is not None and position > 0
 
+            irating = driver.get("IRating")
             if not isinstance(irating, int):
                 continue
-
-            position = None
-
-            if car_idx < len(ctx.positions):
-                raw_position = ctx.positions[car_idx]
-
-                if isinstance(raw_position, int) and raw_position > 0:
-                    position = raw_position
 
             drivers.append(
                 {
                     "id": driver.get("UserID", car_idx),
                     "irating": irating,
                     "position": position,
-                    "started": position is not None,
+                    "class_id": driver.get("CarClassID"),
+                    "started": started,
                 }
             )
 

--- a/backend/services/leaderboard/context.py
+++ b/backend/services/leaderboard/context.py
@@ -21,7 +21,9 @@ class LeaderboardContext(SessionStateContext):
             Cached fastest valid best lap by car class ID.
         est_times (list[float]):
            Estimated time in seconds from the S/F line to the cars current position.
-            
+        irating_deltas (dict[int, int]):
+            Cached iRating deltas for each driver, keyed by driver ID.
+           
     Used by NeighborsService, CarDataBuilder and Leaderboard to construct
     and sort leaderboard telemetry data.
     """
@@ -34,3 +36,4 @@ class LeaderboardContext(SessionStateContext):
     # Set in Leaderboard._build_context(). Keyed by CarClassID.
     class_fastest_laps: dict[int | None, float | None] = field(default_factory=dict)
     est_times: list[float] = field(default_factory=list)
+    irating_deltas: dict[int, int] = field(default_factory=dict)

--- a/backend/services/leaderboard/service.py
+++ b/backend/services/leaderboard/service.py
@@ -69,15 +69,34 @@ class Leaderboard(BaseService):
         Calculate iRating deltas from current leaderboard state.
         Returns mapping: UserID -> delta.
         """
-        drivers = self.builder.build_irating_results(ctx)
+        drivers = self.builder.get_irating_drivers(ctx)
 
-        race_results = {
-            driver["id"]: driver["irating"]
-            for driver in drivers
-            if driver["position"] is not None
-        }
+        classes: dict[int, list[dict[str, Any]]] = {}
 
-        deltas = self.irating_calculator.calculate(race_results)
+        for driver in drivers:
+            if not driver["started"]:
+                continue
+
+            classes.setdefault(
+                driver["class_id"],
+                []
+            ).append(driver)
+
+
+        deltas: dict[int, int] = {}
+
+        for class_id, class_drivers in classes.items():
+
+            race_results = {
+                driver["id"]: driver["irating"]
+                for driver in class_drivers
+            }
+
+            class_deltas = self.irating_calculator.calculate(
+                race_results
+            )
+
+            deltas.update(class_deltas)
 
         return {
             driver_id: delta

--- a/backend/services/leaderboard/service.py
+++ b/backend/services/leaderboard/service.py
@@ -6,6 +6,7 @@ from backend.services.leaderboard.context import LeaderboardContext
 from backend.services.leaderboard.lap_times.formatter import TimeFormatter
 from backend.services.leaderboard.lap_times.service import LapTimeService
 from backend.services.leaderboard.neighbors import NeighborsService
+from backend.utils.irating_calculation import IRatingCalculator
 
 
 class Leaderboard(BaseService):
@@ -16,6 +17,7 @@ class Leaderboard(BaseService):
         builder = CarDataBuilder(irsdk_service, self.lap_times)
         super().__init__(irsdk_service, builder)
         self.neighbors = NeighborsService(builder)
+        self.irating_calculator = IRatingCalculator()
         self._last_session_num: int | None = None
 
     def _build_snapshot(self, ctx: LeaderboardContext) -> dict[str, Any]:
@@ -28,6 +30,7 @@ class Leaderboard(BaseService):
             "neighbors": self.neighbors.get_neighbors(player_idx, ctx),
             "leaderboard_data": self.get_session_info(player_idx, ctx),
             "multiclass": ctx.multiclass,
+            "irating_deltas": ctx.irating_deltas,
         }
 
     def _build_context(self) -> LeaderboardContext | None:
@@ -57,8 +60,29 @@ class Leaderboard(BaseService):
             class_id: self.lap_times.class_fastest_lap(ctx, class_id)
             for class_id in {driver.get("CarClassID") for driver in drivers}
         }
+        ctx.irating_deltas = self._calculate_irating_deltas(ctx)
 
         return ctx
+
+    def _calculate_irating_deltas(self, ctx: LeaderboardContext) -> dict[int, int]:
+        """
+        Calculate iRating deltas from current leaderboard state.
+        Returns mapping: UserID -> delta.
+        """
+        drivers = self.builder.build_irating_results(ctx)
+
+        race_results = {
+            driver["id"]: driver["irating"]
+            for driver in drivers
+            if driver["position"] is not None
+        }
+
+        deltas = self.irating_calculator.calculate(race_results)
+
+        return {
+            driver_id: delta
+            for driver_id, delta in deltas.items()
+        }
 
     def get_session_time(
         self,

--- a/backend/utils/irating_calculation.py
+++ b/backend/utils/irating_calculation.py
@@ -3,6 +3,8 @@ iRacing iRating calculator.
 
 Original algorithm based on the iRacing rating calculation formula.
 Calculations based on:
+https://github.com/arrecio/ircalculator
+https://github.com/Turbo87/irating-rs
 https://github.com/SIMRacingApps/SIMRacingApps/files/3617438/iRacing.SOF.iRating.Calculator.v1_1.xlsx
 """
 
@@ -51,8 +53,8 @@ class IRatingCalculator:
 
     def calculate(
         self,
-        race_results: Mapping[str, int],
-    ) -> dict[str, int]:
+        race_results: Mapping[int, int],
+    ) -> dict[int, int]:
         """
         Calculate iRating delta for each driver.
 
@@ -106,7 +108,7 @@ class IRatingCalculator:
 
     @staticmethod
     def calculate_sof(
-        race_results: Mapping[str, int],
+        race_results: Mapping[int, int],
     ) -> int:
         """
         Calculate Strength of Field.
@@ -131,26 +133,3 @@ class IRatingCalculator:
             -BASE_RATING
             * math.log(total / len(race_results))
         )
-
-
-race = {
-    "Driver 1": 3945,
-    "Driver 2": 1221,
-    "Driver 3": 1322,
-    "Driver 4": 1321,
-    "Meeeee 5": 1479,
-    "Driver 6": 1626,
-    "Driver 7": 1371,
-    "Driver 8": 1448,
-    "Driver 9": 1348,
-}
-
-calculator = IRatingCalculator()
-
-new_ratings = calculator.calculate(race)
-
-race_sof = calculator.calculate_sof(race)
-print(race_sof)
-
-for driver, rating in new_ratings.items():
-    print(driver, rating)

--- a/backend/utils/irating_calculation.py
+++ b/backend/utils/irating_calculation.py
@@ -1,0 +1,156 @@
+"""
+iRacing iRating calculator.
+
+Original algorithm based on the iRacing rating calculation formula.
+Calculations based on:
+https://github.com/SIMRacingApps/SIMRacingApps/files/3617438/iRacing.SOF.iRating.Calculator.v1_1.xlsx
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Mapping
+
+
+LN_2 = 0.693147180559945309417232121458176568
+BASE_RATING = 1600 / LN_2
+
+
+def calculate_win_probability(
+    rating_a: float,
+    rating_b: float,
+    factor: float = BASE_RATING,
+) -> float:
+    """
+    Calculate probability of driver A beating driver B.
+
+    Args:
+        rating_a: First driver's iRating.
+        rating_b: Second driver's iRating.
+        factor: Scaling factor.
+
+    Returns:
+        Probability value.
+    """
+
+    exp_a = math.exp(-rating_a / factor)
+    exp_b = math.exp(-rating_b / factor)
+
+    quality_a = (1 - exp_a) * exp_b
+    quality_b = (1 - exp_b) * exp_a
+
+    return quality_a / (quality_b + quality_a)
+
+
+class IRatingCalculator:
+    """
+    Calculates iRating changes after a race.
+
+    Input order must represent final race positions.
+    """
+
+    def calculate(
+        self,
+        race_results: Mapping[str, int],
+    ) -> dict[str, int]:
+        """
+        Calculate iRating delta for each driver.
+
+        Args:
+            race_results:
+                Mapping where:
+                - key is driver identifier
+                - value is starting iRating.
+
+                Order represents finishing positions.
+
+        Returns:
+            Mapping:
+                {
+                    driver_id: irating_delta,
+                }
+        """
+
+        drivers = list(race_results.items())
+        total_drivers = len(drivers)
+
+        expected_scores = []
+
+        for _, rating in drivers:
+            expected = -0.5
+
+            for _, opponent_rating in drivers:
+                expected += calculate_win_probability(
+                    rating,
+                    opponent_rating,
+                )
+
+            expected_scores.append(expected)
+
+        deltas = {}
+
+        for position, ((driver_id, _), expected) in enumerate(
+            zip(drivers, expected_scores),
+            start=1,
+        ):
+            change = (
+                total_drivers
+                - position
+                - expected
+                - ((total_drivers / 2) - position) / 100
+            ) * 200 / total_drivers
+
+            deltas[driver_id] = round(change)
+
+        return deltas
+
+    @staticmethod
+    def calculate_sof(
+        race_results: Mapping[str, int],
+    ) -> int:
+        """
+        Calculate Strength of Field.
+
+        Args:
+            race_results:
+                Mapping of driver identifiers to starting iRatings.
+
+        Returns:
+            SOF value.
+        """
+
+        if not race_results:
+            return 0
+
+        total = sum(
+            math.exp(-rating / BASE_RATING)
+            for rating in race_results.values()
+        )
+
+        return round(
+            -BASE_RATING
+            * math.log(total / len(race_results))
+        )
+
+
+race = {
+    "Driver 1": 3945,
+    "Driver 2": 1221,
+    "Driver 3": 1322,
+    "Driver 4": 1321,
+    "Meeeee 5": 1479,
+    "Driver 6": 1626,
+    "Driver 7": 1371,
+    "Driver 8": 1448,
+    "Driver 9": 1348,
+}
+
+calculator = IRatingCalculator()
+
+new_ratings = calculator.calculate(race)
+
+race_sof = calculator.calculate_sof(race)
+print(race_sof)
+
+for driver, rating in new_ratings.items():
+    print(driver, rating)

--- a/frontend/static/css/overlays/leaderboard.css
+++ b/frontend/static/css/overlays/leaderboard.css
@@ -1,7 +1,7 @@
 @import url('base.css');
 
 .app {
-  max-width: 420px;
+  max-width: 470px;
   margin: 40px auto;
  }
 
@@ -21,7 +21,7 @@
 
 .thead, .row {
   display: grid;
-  grid-template-columns: 60px 90px 80px 90px 40px;
+  grid-template-columns: 60px 90px 110px 90px 40px;
   align-items: center;
   column-gap: 12px;
 }
@@ -234,12 +234,22 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.ir {
+.ir,
+.ir-delta {
   width: 40px;
   background: rgb(var(--m3-surface-bg), 0.6);
   display: flex;
   align-items: center;
   justify-content: center;
+}
+.ir-delta {
+  color: #888;
+}
+.ir-delta.positive {
+  color: #37D67A;
+}
+.ir-delta.negative {
+  color: #FF5C5C;
 }
 
 .lic.a { background: #007bff; }

--- a/frontend/templates/overlays/leaderboard.html
+++ b/frontend/templates/overlays/leaderboard.html
@@ -29,6 +29,7 @@
                 <div class="lic-container">
                     <span class="lic">--</span>
                     <span class="ir">--</span>
+                    <span class="ir-delta">--</span>
                 </div>
             </div>
             <div class="time">--:--.---</div>
@@ -50,6 +51,7 @@
                 <div class="lic-container">
                     <span class="lic">--</span>
                     <span class="ir">--</span>
+                    <span class="ir-delta">--</span>
                 </div>
             </div>
             <div class="time">--:--.---</div>
@@ -71,6 +73,7 @@
                 <div class="lic-container">
                     <span class="lic">--</span>
                     <span class="ir">--</span>
+                    <span class="ir-delta">--</span>
                 </div>
             </div>
             <div class="time">--:--.---</div>
@@ -93,6 +96,7 @@
                 <div class="lic-container">
                     <span class="lic">--</span>
                     <span class="ir">--</span>
+                    <span class="ir-delta">--</span>
                 </div>
             </div>
             <div class="time">--:--.---</div>
@@ -115,6 +119,7 @@
                 <div class="lic-container">
                     <span class="lic">--</span>
                     <span class="ir">--</span>
+                    <span class="ir-delta">--</span>
                 </div>
             </div>
             <div class="time">--:--.---</div>
@@ -136,6 +141,7 @@
                 <div class="lic-container">
                     <span class="lic">--</span>
                     <span class="ir">--</span>
+                    <span class="ir-delta">--</span>
                 </div>
             </div>
             <div class="time">--:--.---</div>
@@ -157,6 +163,7 @@
                 <div class="lic-container">
                     <span class="lic">--</span>
                     <span class="ir">--</span>
+                    <span class="ir-delta">--</span>
                 </div>
             </div>
             <div class="time">--:--.---</div>
@@ -373,15 +380,7 @@ class LeaderboardUpdater extends BaseUpdater {
 
     renderDriverName(rowElement, car) {
         const nameElement = rowElement.querySelector('.driver .name');
-        const delta = this.data?.irating_deltas?.[car.driver_id];
-
-        let deltaText = '';
-
-        if (delta !== undefined && delta !== null) {
-            deltaText = `${delta > 0 ? '+' : ''}${delta} `;
-        }
-
-        nameElement.textContent = `${deltaText}${car.name || 'Unknown'}`;
+        nameElement.textContent = car.name || 'Unknown';
 
         nameElement.classList.remove(
             'with-flag',
@@ -410,6 +409,29 @@ class LeaderboardUpdater extends BaseUpdater {
         irElement.textContent = car.irating
             ? (Math.floor(car.irating / 100) / 10).toFixed(1) + 'k'
             : '--';
+
+        this.renderIratingDelta(rowElement, car);
+    }
+
+    renderIratingDelta(rowElement, car) {
+        const deltaElement = rowElement.querySelector('.ir-delta');
+        if (!deltaElement) return;
+
+        const delta = this.data?.irating_deltas?.[car.driver_id];
+        deltaElement.className = 'ir-delta';
+
+        if (delta === undefined || delta === null) {
+            deltaElement.textContent = '--';
+            return;
+        }
+
+        deltaElement.textContent = `${delta > 0 ? '+' : ''}${delta}`;
+
+        if (delta > 0) {
+            deltaElement.classList.add('positive');
+        } else if (delta < 0) {
+            deltaElement.classList.add('negative');
+        }
     }
 
     renderGapAndLap(rowElement, car) {

--- a/frontend/templates/overlays/leaderboard.html
+++ b/frontend/templates/overlays/leaderboard.html
@@ -193,6 +193,7 @@ class LeaderboardUpdater extends BaseUpdater {
     }
 
     async renderOverlay(data) {
+        this.data = data;
         this.renderLeaderboard(data);
     }
 
@@ -310,38 +311,83 @@ class LeaderboardUpdater extends BaseUpdater {
 
     renderDriver(rowElement, car) {
         if (!car) return;
+        this.renderDriverName(rowElement, car);
+        this.renderPitFlag(rowElement, car);
+    }
+
+    renderPitFlag(rowElement, car) {
         const nameElement = rowElement.querySelector('.driver .name');
         const pitFlag = rowElement.querySelector('.driver .pit-flag');
 
-        nameElement.textContent = car.name || 'Unknown';
-        nameElement.classList.remove('with-flag', 'in-pit', 'gradient');
-
-        let pitLapText = car.last_pit_lap;
-        if (pitLapText === "IN L0") {
-            pitLapText = "IN PIT";
-        }
-        if (pitLapText === "L0") {
-            pitLapText = "";
-        }
-        if (pitLapText === "OUT L0") {
-            pitLapText = "OUT PIT";
-        }
+        let pitLapText = this.formatPitLap(car.last_pit_lap);
 
         if (car.is_in_pitroad) {
-            nameElement.classList.add('with-flag', 'in-pit', 'gradient');
-            if (pitLapText) {
-                pitFlag.textContent = pitLapText;
-                pitFlag.style.display = 'inline-flex';
-            } else {
-                pitFlag.style.display = 'none';
-            }
-        } else if (pitLapText) {
-            nameElement.classList.add('with-flag', 'gradient');
-            pitFlag.textContent = pitLapText;
-            pitFlag.style.display = 'inline-flex';
-        } else {
-            pitFlag.style.display = 'none';
+            nameElement.classList.add(
+                'with-flag',
+                'in-pit',
+                'gradient'
+            );
+
+            this.showPitFlag(pitFlag, pitLapText);
+            return;
         }
+
+        if (pitLapText) {
+            nameElement.classList.add(
+                'with-flag',
+                'gradient'
+            );
+
+            this.showPitFlag(pitFlag, pitLapText);
+            return;
+        }
+
+        pitFlag.style.display = 'none';
+    }
+
+    formatPitLap(pitLapText) {
+        switch (pitLapText) {
+            case "IN L0":
+                return "IN PIT";
+
+            case "L0":
+                return "";
+
+            case "OUT L0":
+                return "OUT PIT";
+
+            default:
+                return pitLapText;
+        }
+    }
+
+    showPitFlag(element, text) {
+        if (!text) {
+            element.style.display = 'none';
+            return;
+        }
+
+        element.textContent = text;
+        element.style.display = 'inline-flex';
+    }
+
+    renderDriverName(rowElement, car) {
+        const nameElement = rowElement.querySelector('.driver .name');
+        const delta = this.data?.irating_deltas?.[car.driver_id];
+
+        let deltaText = '';
+
+        if (delta !== undefined && delta !== null) {
+            deltaText = `${delta > 0 ? '+' : ''}${delta} `;
+        }
+
+        nameElement.textContent = `${deltaText}${car.name || 'Unknown'}`;
+
+        nameElement.classList.remove(
+            'with-flag',
+            'in-pit',
+            'gradient'
+        );
     }
 
     renderLicenseAndIrating(rowElement, car) {

--- a/tests/backend/leaderboard/conftest.py
+++ b/tests/backend/leaderboard/conftest.py
@@ -72,6 +72,7 @@ def mock_ctx(mock_values: Callable) -> LeaderboardContext:
         "is_pitroad": values.get_value("CarIdxOnPitRoad"),
         "multiclass": False,
         "est_times": values.get_value("CarIdxEstTime"),
+        "irating_deltas": {},
     }
 
     def _make_ctx(**overrides):
@@ -91,6 +92,7 @@ def mock_values(irsdk_mock_factory):
     def _factory(is_multiclass: bool = False) -> dict:
         drivers = [
             {
+                "UserID": 101,
                 "UserName": "Driver1",
                 "IRating": 2000,
                 "LicString": "A 4.99",
@@ -100,6 +102,7 @@ def mock_values(irsdk_mock_factory):
                 "CarClassEstLapTime": 80.0,
             },
             {
+                "UserID": 102,
                 "UserName": "Driver2",
                 "IRating": 1800,
                 "LicString": "B 3.12",
@@ -109,6 +112,7 @@ def mock_values(irsdk_mock_factory):
                 "CarClassEstLapTime": 80.0,
             },
             {
+                "UserID": 103,
                 "UserName": "Driver3",
                 "IRating": 1700,
                 "LicString": "C 2.50",

--- a/tests/backend/leaderboard/test_car_data_builder.py
+++ b/tests/backend/leaderboard/test_car_data_builder.py
@@ -197,3 +197,104 @@ def test_build_all_sorted_by_position(mock_builder, mock_ctx):
 
     positions = [car["pos"] for car in cars]
     assert positions == sorted(positions)
+
+
+def test_get_irating_drivers_returns_ordered_eligible_drivers(mock_builder, mock_ctx):
+    ctx = mock_ctx(
+        drivers=[
+            {
+                "UserName": "Driver1",
+                "UserID": 101,
+                "IRating": 2000,
+                "CarClassID": 1,
+            },
+            {
+                "UserName": "Driver2",
+                "UserID": 102,
+                "IRating": 1800,
+                "CarClassID": 1,
+            },
+            {
+                "UserName": "Driver3",
+                "UserID": 103,
+                "IRating": 1700,
+                "CarClassID": 2,
+            },
+        ],
+        positions=[3, 1, 2],
+    )
+
+    result = mock_builder.get_irating_drivers(ctx)
+
+    assert result == [
+        {
+            "id": 102,
+            "irating": 1800,
+            "position": 1,
+            "class_id": 1,
+            "started": True,
+        },
+        {
+            "id": 103,
+            "irating": 1700,
+            "position": 2,
+            "class_id": 2,
+            "started": True,
+        },
+        {
+            "id": 101,
+            "irating": 2000,
+            "position": 3,
+            "class_id": 1,
+            "started": True,
+        },
+    ]
+
+
+def test_get_irating_drivers_skips_pace_car_and_invalid_irating(
+    mock_builder,
+    mock_ctx,
+):
+    ctx = mock_ctx(
+        drivers=[
+            {"UserName": "PACE CAR", "IRating": 0, "CarClassID": 1},
+            {
+                "UserName": "Driver1",
+                "UserID": 101,
+                "IRating": "invalid",
+                "CarClassID": 1,
+            },
+            {
+                "UserName": "Driver2",
+                "UserID": 102,
+                "IRating": 1800,
+                "CarClassID": 1,
+            },
+        ],
+        positions=[1, 2, 3],
+    )
+
+    result = mock_builder.get_irating_drivers(ctx)
+
+    assert result == [
+        {
+            "id": 102,
+            "irating": 1800,
+            "position": 3,
+            "class_id": 1,
+            "started": True,
+        }
+    ]
+
+
+def test_get_irating_drivers_marks_unresolved_position_as_not_started(
+    mock_builder,
+    mock_ctx,
+):
+    ctx = mock_ctx(positions=[-1, 1, 2])
+
+    result = mock_builder.get_irating_drivers(ctx)
+
+    assert result[-1]["id"] == 101
+    assert result[-1]["position"] is None
+    assert result[-1]["started"] is False

--- a/tests/backend/leaderboard/test_leaderboard.py
+++ b/tests/backend/leaderboard/test_leaderboard.py
@@ -167,3 +167,53 @@ def test_build_context_returns_none_when_no_drivers(irsdk_mock_factory):
 )
 def test_normalize_laps_started(mock_service, raw_laps, expected):
     assert mock_service._normalize_laps_started(raw_laps) == expected
+
+
+def test_build_snapshot_includes_cached_irating_deltas(mock_service, mock_ctx):
+    ctx = mock_ctx(irating_deltas={101: 60, 102: 2, 103: -60})
+
+    snapshot = mock_service._build_snapshot(ctx)
+
+    assert snapshot["irating_deltas"] == {101: 60, 102: 2, 103: -60}
+
+
+def test_calculate_irating_deltas_uses_finishing_order_by_class(
+    mock_service,
+    mock_ctx,
+):
+    ctx = mock_ctx(
+        drivers=[
+            {
+                "UserName": "Driver1",
+                "UserID": 101,
+                "IRating": 2000,
+                "CarClassID": 1,
+            },
+            {
+                "UserName": "Driver2",
+                "UserID": 102,
+                "IRating": 1800,
+                "CarClassID": 2,
+            },
+            {
+                "UserName": "Driver3",
+                "UserID": 103,
+                "IRating": 1700,
+                "CarClassID": 1,
+            },
+            {
+                "UserName": "Driver4",
+                "UserID": 104,
+                "IRating": 1600,
+                "CarClassID": 2,
+            },
+        ],
+        positions=[2, 1, 1, -1],
+        class_positions=[2, 1, 1, -1],
+        multiclass=True,
+    )
+
+    result = mock_service._calculate_irating_deltas(ctx)
+
+    assert result == {103: 56, 101: -55, 102: 1}
+    assert 104 not in result

--- a/tests/backend/test_irating_calculation.py
+++ b/tests/backend/test_irating_calculation.py
@@ -1,0 +1,59 @@
+import pytest
+
+from backend.utils.irating_calculation import (
+    IRatingCalculator,
+    calculate_win_probability,
+)
+
+
+@pytest.mark.parametrize(
+    "rating_a,rating_b,expected",
+    [
+        (2000, 2000, 0.5),
+        (2000, 1800, 0.5385630371161682),
+        (1800, 2000, 0.4614369628838318),
+    ],
+)
+def test_calculate_win_probability(rating_a, rating_b, expected):
+    result = calculate_win_probability(rating_a, rating_b)
+
+    assert result == pytest.approx(expected)
+
+
+def test_calculate_win_probability_is_complementary():
+    driver_a = calculate_win_probability(2200, 1600)
+    driver_b = calculate_win_probability(1600, 2200)
+
+    assert driver_a + driver_b == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "race_results,expected_deltas",
+    [
+        ({1: 2000, 2: 1800, 3: 1700}, {1: 60, 2: 2, 3: -60}),
+        ({1: 1000, 2: 2000}, {1: 72, 2: -71}),
+        ({2: 1800}, {2: 1}),
+    ],
+)
+def test_irating_calculator_calculates_deltas(race_results, expected_deltas):
+    calculator = IRatingCalculator()
+
+    result = calculator.calculate(race_results)
+
+    assert result == expected_deltas
+
+
+@pytest.mark.parametrize(
+    "race_results,expected_sof",
+    [
+        ({}, 0),
+        ({1: 2000, 2: 1800, 3: 1700}, 1830),
+        ({1: 1000, 2: 2000}, 1446),
+    ],
+)
+def test_irating_calculator_calculates_sof(race_results, expected_sof):
+    calculator = IRatingCalculator()
+
+    result = calculator.calculate_sof(race_results)
+
+    assert result == expected_sof


### PR DESCRIPTION
### Key features:
- Overlay:
1. add the ability to view the calculated iRating delta during the race. https://github.com/onesch/redwave-overlays/issues/13

- Test:
2. update leadeboard tests to match new behavior.

- Image:
<img width="504" height="254" alt="leaderboard" src="https://github.com/user-attachments/assets/a45c5936-fdc1-4ea5-99f7-0e63f939f1c9" />
